### PR TITLE
Add macros and stylesheet attributes to web-component

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Options:
   -p, --pretty           beautify the html (this may add/remove spaces unintentionally)
   -c, --class <class>    set a default documentclass for documents without a preamble (default: article)
   -m, --macros <file>    load a JavaScript file with additional custom macros
-  -s, --style <url>      specify an additional style sheet to use (can be repeated)
+  -s, --stylesheet <url> specify an additional style sheet to use (can be repeated)
   -n, --no-hyphenation   don't insert soft hyphens (disables automatic hyphenation in the browser)
   -l, --language <lang>  set hyphenation language (default: en)
   -h, --help             output usage information

--- a/src/cli.ls
+++ b/src/cli.ls
@@ -75,7 +75,7 @@ if program.macros
         CustomMacros = CustomMacros[path.parse macros .name]
 
 
-if program.body and (program.style or program.url)
+ if program.body and (program.stylesheet or program.url)
     console.error "error: conflicting options: 'url' and 'stylesheet' cannot be used with 'body'!"
     process.exit 1
 

--- a/src/cli.ls
+++ b/src/cli.ls
@@ -52,7 +52,7 @@ program
     # options about LaTeX and style
     .option '-c, --class <class>',      'set a default documentclass for documents without a preamble', 'article'
     .option '-m, --macros <file>',      'load a JavaScript file with additional custom macros'
-    .option '-s, --style <url>',        'specify an additional style sheet to use (can be repeated)', addStyle
+    .option '-s, --stylesheet <url>',   'specify an additional style sheet to use (can be repeated)', addStyle
 
     .option '-n, --no-hyphenation',     'don\'t insert soft hyphens (disables automatic hyphenation in the browser)'
     .option '-l, --language <lang>',    'set hyphenation language', 'en'

--- a/src/cli.ls
+++ b/src/cli.ls
@@ -76,7 +76,7 @@ if program.macros
 
 
 if program.body and (program.style or program.url)
-    console.error "error: conflicting options: 'url' and 'style' cannot be used with 'body'!"
+    console.error "error: conflicting options: 'url' and 'stylesheet' cannot be used with 'body'!"
     process.exit 1
 
 

--- a/src/latex.component.js
+++ b/src/latex.component.js
@@ -43,6 +43,7 @@ customElements.define('latex-js',
       if (this.hasAttribute("macros"))
         CustomMacros = (await import(this.getAttribute("macros"))).default
 
+
       // parse
       const generator = latexjs.parse(this.textContent, { generator: new latexjs.HtmlGenerator({ hyphenate, CustomMacros }) })
 
@@ -52,6 +53,14 @@ customElements.define('latex-js',
       page.appendChild(generator.domFragment())
 
       generator.applyLengthsAndGeometryToDom(this.shadow.host)
+
+      if (this.hasAttribute("stylesheet")) {
+        const style = document.createElement("link")
+        style.type = "text/css"
+        style.rel = "stylesheet"
+        style.href = this.getAttribute("stylesheet")
+        this.shadow.appendChild(style)
+      }
 
       this.shadow.appendChild(generator.stylesAndScripts(path))
       this.shadow.appendChild(page)

--- a/src/latex.component.js
+++ b/src/latex.component.js
@@ -27,7 +27,7 @@ customElements.define('latex-js',
       this.shadow =  this.attachShadow({mode: 'open'})
     }
 
-    onContentReady() {
+    async onContentReady() {
       // empty DOM
       while (this.shadow.lastChild) {
         this.shadow.lastChild.remove()
@@ -39,8 +39,12 @@ customElements.define('latex-js',
       if (this.hasAttribute("baseURL"))
         path = this.getAttribute("baseURL")
 
+      let CustomMacros;
+      if (this.hasAttribute("macros"))
+        CustomMacros = (await import(this.getAttribute("macros"))).default
+
       // parse
-      const generator = latexjs.parse(this.textContent, { generator: new latexjs.HtmlGenerator({ hyphenate: hyphenate }) })
+      const generator = latexjs.parse(this.textContent, { generator: new latexjs.HtmlGenerator({ hyphenate, CustomMacros }) })
 
       // create DOM
       let page = document.createElement("div")


### PR DESCRIPTION
Hi Michael, I added `macros` and `stylesheet` attributes to the component.
We can use the component with similar API of CLI by this request.
For example,

```html
<latex-js macros="https://example.com/macros.js" stylesheet="https://example.com/style.css">
\documentclass{article}
\begin{document}
Hello!
\end{document}
</latex-js>
```

Cheers!