### PR TITLE
Read styles from cli option `stylesheet`, not `style`.

### DIFF
--- a/src/cli.ls
+++ b/src/cli.ls
@@ -88,7 +88,7 @@ const htmlOptions =
                         | otherwise console.error "error: language '#{that}' is not supported yet"; process.exit 1
     documentClass:      options.class
     CustomMacros:       CustomMacros
-    styles:             options.style || []
+    styles:             options.stylesheet || []
 
 
 


### PR DESCRIPTION
The `--stylesheet` command line option wasn't working.

I made my local copy work by editing `bin/latex.js` in my `node_modules`. That fixed my problem, so here I made what seems to be the corresponding change to the source file. I have not yet tested by building the latex.js project.