### PR TITLE
Bump KaTeX to 0.16 with conditional-exports import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   },
   "devDependencies": {
     "he": "1.2.x",
-    "katex": "0.13.13",
+    "katex": "^0.16.10",
     "@svgdotjs/svg.js": "https://github.com/michael-brade/svg.js",
     "hypher": "0.x",
     "lodash": "4.x",

--- a/package.json.sh
+++ b/package.json.sh
@@ -132,7 +132,7 @@ devDependencies:
     ### actual runtime dependencies, but bundled by rollup
 
     'he': '1.2.x'
-    'katex': '0.13.13'
+    'katex': '^0.16.10'
     '@svgdotjs/svg.js': 'https://github.com/michael-brade/svg.js'  # '3.x'
 
     'hypher': '0.x'

--- a/src/html-generator.ls
+++ b/src/html-generator.ls
@@ -2,7 +2,7 @@ import
     './generator': { Generator }
     './symbols': { ligatures, diacritics }
     '@svgdotjs/svg.js': { SVG }
-    'katex/dist/katex.mjs': katex
+    'katex': katex
 
     'hypher': Hypher
     'hyphenation.en-us': h-en


### PR DESCRIPTION
Updates KaTeX from 0.13.13 to 0.16.x via the conditional-exports
import form (\`katex/dist/katex.mjs\` -> \`katex\`). Supersedes #150.

KaTeX 0.13.13 -> 0.16.x breaking changes affecting LaTeX.js
(from the KaTeX changelog):

- 0.14.0: conditional-exports paths (this PR's main change).
- 0.15.0: \`\relax\` reimplemented; minor source-level math
  regression risk only.
- 0.16.0: \`copy-tex.css\` removed (LaTeX.js doesn't import it).

\`renderToString(latex, options)\` - LaTeX.js's actual KaTeX call
surface - is signature-unchanged. The \`trust\` option semantics
are unchanged.

Stacks on top of #163.